### PR TITLE
Add rsync to hasta after X complete

### DIFF
--- a/scripts/checkfornewdemux.bash
+++ b/scripts/checkfornewdemux.bash
@@ -74,6 +74,8 @@ for run in ${UNABASE}/*; do
                 rsync -rvtl ${UNABASE}${run} hasta:${HASTA_DEMUXES_DIR}
                 log "ssh hasta \"find -L ${HASTA_DEMUXES_DIR}/${run} -type l -printf 'ln -sf %l %h/%f\n' | sed s'|${UNABASE}|${HASTA_DEMUXES_DIR}|' | sh\""
                 ssh hasta "find -L ${HASTA_DEMUXES_DIR}/${run} -type l -printf 'ln -sf %l %h/%f\n' | sed s'|${UNABASE}|${HASTA_DEMUXES_DIR}|' | sh"
+                log "column -t ${UNABASE}${run}/stats*.txt | mail -s 'Run ${SUBJECT} synced to hasta!' ${MAILTO}"
+                column -t ${UNABASE}${run}/stats*.txt | mail -s "Run ${SUBJECT} synced to hasta!" ${MAILTO}
             fi
         fi
     else


### PR DESCRIPTION
How to test:

0. clone this branch to e.g. /mnt/hds/proj/bioinfo/git/you/
1. `rm /mnt/hds/proj/bioinfo/DEMUX/180515_ST-E00214_0221_BHLFTLCCXY/delivery.txt`
2. `bash /mnt/hds/proj/bioinfo/git/you/deliver/scripts/checkfornewdemux.bash`

Expected outcome:
- rsync to hasta starts
- Check the following with hasta:/home/proj/production/demultiplexed-runs/180515_ST-E00214_0221_BHLFTLCCXY:
  - run dir size is 600GB+
  - run dir has l?t?? dirs
  - links are not broken: `find . -xtype l` yields no results