### PR TITLE
Hasta cg transfer

### DIFF
--- a/scripts/checkfornewdemux.bash
+++ b/scripts/checkfornewdemux.bash
@@ -74,6 +74,8 @@ for run in ${UNABASE}/*; do
                 rsync -rvtl ${UNABASE}${run} hasta:${HASTA_DEMUXES_DIR}
                 log "ssh hasta \"find -L ${HASTA_DEMUXES_DIR}/${run} -type l -printf 'ln -sf %l %h/%f\n' | sed s'|${UNABASE}|${HASTA_DEMUXES_DIR}|' | sh\""
                 ssh hasta "find -L ${HASTA_DEMUXES_DIR}/${run} -type l -printf 'ln -sf %l %h/%f\n' | sed s'|${UNABASE}|${HASTA_DEMUXES_DIR}|' | sh"
+                log "ssh hasta \"rm ${HASTA_DEMUXES_DIR}/${run}/delivery.txt\""
+                ssh hasta "rm ${HASTA_DEMUXES_DIR}/${run}/delivery.txt"
                 log "column -t ${UNABASE}${run}/stats*.txt | mail -s 'Run ${SUBJECT} synced to hasta!' ${MAILTO}"
                 column -t ${UNABASE}${run}/stats*.txt | mail -s "Run ${SUBJECT} synced to hasta!" ${MAILTO}
             fi

--- a/scripts/checkfornewdemuxonhasta.bash
+++ b/scripts/checkfornewdemuxonhasta.bash
@@ -8,9 +8,8 @@ useprod
 # VARS #
 ########
 
-#ERROR_EMAIL=clinical-demux@scilifelab.se
-ERROR_EMAIL=kenny.billiau@scilifelab.se
-HASTA_DEMUXES_DIR=/home/proj/production/demultiplexed-runs/
+ERROR_EMAIL=clinical-demux@scilifelab.se
+HASTA_DEMUXES_DIR=${PROJECT_HOME}/${ENVIRONMENT}/demultiplexed-runs/
 
 #############
 # FUNCTIONS #

--- a/scripts/checkfornewdemuxonhasta.bash
+++ b/scripts/checkfornewdemuxonhasta.bash
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+shopt -s expand_aliases
+source ${HOME}/.bashrc
+useprod
+
+########
+# VARS #
+########
+
+#ERROR_EMAIL=clinical-demux@scilifelab.se
+ERROR_EMAIL=kenny.billiau@scilifelab.se
+HASTA_DEMUXES_DIR=/home/proj/production/demultiplexed-runs/
+
+#############
+# FUNCTIONS #
+#############
+
+log() {
+    local NOW=$(date +"%Y%m%d%H%M%S")
+    echo "[$NOW] $@"
+}
+
+failed() {
+    echo "Error delivering ${FC}: $(caller)" | mail -s "ERROR delivery ${FC}" ${ERROR_EMAIL}
+}
+trap failed ERR
+
+########
+# MAIN #
+########
+
+for run in ${HASTA_DEMUXES_DIR}/*; do
+    run=$(basename $run)
+    if [[ -f ${HASTA_DEMUXES_DIR}${run}/copycomplete.txt ]]; then
+        if [[ -f ${HASTA_DEMUXES_DIR}${run}/delivery.txt ]]; then
+            log ${run} 'copy is complete and delivery has already started'
+        else
+            log ${run} 'copy is complete delivery is started' > ${HASTA_DEMUXES_DIR}${run}/delivery.txt
+            FC=$(echo ${run} | awk 'BEGIN {FS="/"} {split($(NF-1),arr,"_");print substr(arr[4],2,length(arr[4]))}')
+  
+            NOW=$(date +"%Y%m%d%H%M%S")
+            cg transfer flowcell $FC &> ${HASTA_DEMUXES_DIR}${run}/cg.transfer.${FC}.${NOW}.log
+        fi
+    else
+        log ${run} 'is not yet completely copied'
+    fi
+done


### PR DESCRIPTION
This is a fun one!

This PR solves two things:
1/ Now we are copying HKdb from rasta to HKdb for hasta. This would _overwrite_ all changes made to HKdb for hasta with only the changes made to HKdb rasta each night. All new result bundles made on hasta would "disappear". So, we need to stop the copying.
2/ stopping the copying does mean we are not applying the changes to HKdb for rasta to HKdb for hasta. All new fastq files "cg transferred" on rasta would never make it to hasta. We need to make sure that "cg transfer" is also triggered on hasta.

Once this PR is in production we also need to merge https://github.com/Clinical-Genomics/servers/pull/88


This PR has not been tested yet :)
