### PR TITLE
Move functionality checkfornewdemux rasta -> hasta

### DIFF
--- a/scripts/checkfornewdemux.bash
+++ b/scripts/checkfornewdemux.bash
@@ -58,16 +58,7 @@ for run in ${UNABASE}/*; do
   
             NOW=$(date +"%Y%m%d%H%M%S")
             deliver microbial --flowcell $FC &> ${UNABASE}${run}/microbial.${FC}.${NOW}.log
-            cg transfer flowcell $FC &> ${UNABASE}${run}/cg.transfer.${FC}.${NOW}.log
   
-            # link the fastq files to custXXX/inbox
-            deliver_fastqs_fc ${FC}
-  
-            SUBJECT=${FC}
-            # send an email on completion
-            log "column -t ${UNABASE}${run}/stats*.txt | mail -s 'Run ${SUBJECT} COMPLETE!' ${MAILTO}"
-            column -t ${UNABASE}${run}/stats*.txt | mail -s "Run ${SUBJECT} COMPLETE!" ${MAILTO}
-
             # post X action: copy to hasta
             if [[ -d "${UNABASE}${run}/l1t11" ]]; then
                 log "rsync -rvtl ${UNABASE}${run} hasta:${HASTA_DEMUXES_DIR}"
@@ -76,8 +67,6 @@ for run in ${UNABASE}/*; do
                 ssh hasta "find -L ${HASTA_DEMUXES_DIR}/${run} -type l -printf 'ln -sf %l %h/%f\n' | sed s'|${UNABASE}|${HASTA_DEMUXES_DIR}|' | sh"
                 log "ssh hasta \"rm ${HASTA_DEMUXES_DIR}/${run}/delivery.txt\""
                 ssh hasta "rm ${HASTA_DEMUXES_DIR}/${run}/delivery.txt"
-                log "column -t ${UNABASE}${run}/stats*.txt | mail -s 'Run ${SUBJECT} synced to hasta!' ${MAILTO}"
-                column -t ${UNABASE}${run}/stats*.txt | mail -s "Run ${SUBJECT} synced to hasta!" ${MAILTO}
             fi
         fi
     else

--- a/scripts/checkfornewdemuxonhasta.bash
+++ b/scripts/checkfornewdemuxonhasta.bash
@@ -9,7 +9,7 @@ useprod
 ########
 
 HASTA_DEMUXES_DIR=${1-${PROJECT_HOME}/${ENVIRONMENT}/demultiplexed-runs/}
-ERROR_EMAIL=${2-clinical-demux@scilifelab.se}
+MAILTO=${2-clinical-demux@scilifelab.se}
 
 #############
 # FUNCTIONS #
@@ -21,7 +21,7 @@ log() {
 }
 
 failed() {
-    echo "Error delivering ${FC}: $(caller)" | mail -s "ERROR delivery ${FC}" ${ERROR_EMAIL}
+    echo "Error delivering ${FC}: $(caller)" | mail -s "ERROR delivery ${FC}" ${MAILTO}
 }
 trap failed ERR
 
@@ -43,8 +43,8 @@ for run in ${HASTA_DEMUXES_DIR}/*; do
 
             # send an email on completion
             SUBJECT=${FC}
-            log "column -t ${UNABASE}${run}/stats*.txt | mail -s 'Run ${SUBJECT} COMPLETE!' ${MAILTO}"
-            column -t ${UNABASE}${run}/stats*.txt | mail -s "Run ${SUBJECT} COMPLETE!" ${MAILTO}
+            log "column -t ${HASTA_DEMUXES_DIR}/${run}/stats*.txt | mail -s 'Run ${SUBJECT} COMPLETE!' ${MAILTO}"
+            column -t ${HASTA_DEMUXES_DIR}/${run}/stats*.txt | mail -s "Run ${SUBJECT} COMPLETE!" ${MAILTO}
         fi
     else
         log ${run} 'is not yet completely copied'

--- a/scripts/checkfornewdemuxonhasta.bash
+++ b/scripts/checkfornewdemuxonhasta.bash
@@ -8,8 +8,8 @@ useprod
 # VARS #
 ########
 
-ERROR_EMAIL=clinical-demux@scilifelab.se
-HASTA_DEMUXES_DIR=${PROJECT_HOME}/${ENVIRONMENT}/demultiplexed-runs/
+HASTA_DEMUXES_DIR=${1-${PROJECT_HOME}/${ENVIRONMENT}/demultiplexed-runs/}
+ERROR_EMAIL=${2-clinical-demux@scilifelab.se}
 
 #############
 # FUNCTIONS #

--- a/scripts/checkfornewdemuxonhasta.bash
+++ b/scripts/checkfornewdemuxonhasta.bash
@@ -40,6 +40,11 @@ for run in ${HASTA_DEMUXES_DIR}/*; do
   
             NOW=$(date +"%Y%m%d%H%M%S")
             cg transfer flowcell $FC &> ${HASTA_DEMUXES_DIR}${run}/cg.transfer.${FC}.${NOW}.log
+
+            # send an email on completion
+            SUBJECT=${FC}
+            log "column -t ${UNABASE}${run}/stats*.txt | mail -s 'Run ${SUBJECT} COMPLETE!' ${MAILTO}"
+            column -t ${UNABASE}${run}/stats*.txt | mail -s "Run ${SUBJECT} COMPLETE!" ${MAILTO}
         fi
     else
         log ${run} 'is not yet completely copied'


### PR DESCRIPTION
This is current situation:
- on rasta
  - will do cg transfer and add to housekeeper-rasta
  - will send an email that the flowcell is now delivered
  - will transfer X flowcell to hasta
- on hasta
  - will do a cg transfer and add to housekeeper-hasta
  - does not send an email

This pull request fixes that to following situation:
- on rasta
  - will transfer X flowcells to hasta
- on hasta
  - will do a cg transfer and add to housekeeper-hasta
  - will send an email


How to test?
- on hasta
0. install on hasta. Clone it to your local user: `git clone https://github.com/clinical-genomics/deliver.git ~/git/deliver` (did not test the url here)
1. `us`
1. Remove the `delivery.txt` file of `/home/proj/stage/demultiplexed-runs/190208_A00689_0009_AHHMGWDSXX`
1. run: `~/git/deliver/scripts/checkfornewrunonhasta.bash /home/proj/stage/demultiplexed-runs/  your@email`

Expected outcome:
```
181218_ST-E00266_0336_BHVTWHCCXY copy is complete and delivery has already started
column -t 190208_A00689_0009_AHHMGWDSXX/stats*.txt | mail -s 'Run  HHMGWDSXX COMPLETE!' 
```

- On rasta
0. install on rasta. We dont have a proper stage set up here, just clone it soemwhere: `git clone https://github.com/clinical-genomics/deliver.git /mnt/hds/proj/bioinfo/git/<yourname>/deliver` (did not test the url here)
1. Remove the `delivery.txt` file of any X-run, e.g. 180212_ST-E00198_0282_AHHJFMCCXY
2. run: `bash /mnt/hds/proj/bioinfo/git/<yourname>/deliver/scripts/checkfornewrun.bash`

expected outcome:
```
...
rsync -rvtl /mnt/hds/proj/bioinfo/DEMUX/180212_ST-E00198_0282_AHHJFMCCXY hasta:/home/proj/production/demultiplexed-runs/
```