### PR TITLE
fix(sourcing): Rm sourcing

### DIFF
--- a/scripts/checkfornewdemux.bash
+++ b/scripts/checkfornewdemux.bash
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-shopt -s expand_aliases
-source ~/.bashrc
-
 ########
 # VARS #
 ########
@@ -10,7 +7,7 @@ source ~/.bashrc
 MAILTO=clinical-demux@scilifelab.se
 ERROR_EMAIL=clinical-demux@scilifelab.se
 UNABASE=/mnt/hds/proj/bioinfo/DEMUX/
-HASTA_DEMUXES_DIR=/home/proj/production/demultiplexed-runs/
+HASTA_DEMUXES_DIR=/home/proj/${ENVIRONMENT}/demultiplexed-runs/
 
 #############
 # FUNCTIONS #

--- a/scripts/checkfornewdemuxonhasta.bash
+++ b/scripts/checkfornewdemuxonhasta.bash
@@ -27,15 +27,32 @@ trap failed ERR
 
 for run in ${HASTA_DEMUXES_DIR}/*; do
     run=$(basename $run)
-    if [[ -f ${HASTA_DEMUXES_DIR}${run}/copycomplete.txt ]]; then
-        if [[ -f ${HASTA_DEMUXES_DIR}${run}/delivery.txt ]]; then
+    if [[ -f ${HASTA_DEMUXES_DIR}/${run}/copycomplete.txt ]]; then
+        if [[ -f ${HASTA_DEMUXES_DIR}/${run}/delivery.txt ]]; then
             log ${run} 'copy is complete and delivery has already started'
         else
-            log ${run} 'copy is complete delivery is started' > ${HASTA_DEMUXES_DIR}${run}/delivery.txt
+            log ${run} 'copy is complete delivery is started' > ${HASTA_DEMUXES_DIR}/${run}/delivery.txt
             FC=$(echo ${run} | awk 'BEGIN {FS="/"} {split($(NF-1),arr,"_");print substr(arr[4],2,length(arr[4]))}')
+
+            # add an X FC to clinstatsdb - because the permanent tunnel is not active on the nodes.
+            if [[ -d "${HASTA_DEMUXES_DIR}/${run}/l1t11" ]]; then
+                log "cgstats add --machine X ${HASTA_DEMUXES_DIR}/${run}"
+                cgstats add --machine X ${HASTA_DEMUXES_DIR}/${run}
+                # create stats per project
+                for PROJECT in ${HASTA_DEMUXES_DIR}/${run}/Unaligned/Project*; do
+                    PROJECT=$(basename $PROJECT)
+                    PROJECT_NR=${PROJECT##*_}
+                    log "cgstats select --project ${PROJECT_NR} ${FC} &> ${HASTA_DEMUXES_DIR}/${run}/stats-${PROJECT_NR}-${FC}.txt"
+                    cgstats select --project ${PROJECT_NR} ${FC} &> ${HASTA_DEMUXES_DIR}/${run}/stats-${PROJECT_NR}-${FC}.txt
+                done
+                # create stats per lane
+                log "cgstats lanestats ${HASTA_DEMUXES_DIR}/${run} &> ${HASTA_DEMUXES_DIR}/${run}/stats.txt"
+                cgstats lanestats ${HASTA_DEMUXES_DIR}/${run} &> ${HASTA_DEMUXES_DIR}/${run}/stats.txt
+            fi
+            # end add
   
             NOW=$(date +"%Y%m%d%H%M%S")
-            cg transfer flowcell $FC &> ${HASTA_DEMUXES_DIR}${run}/cg.transfer.${FC}.${NOW}.log
+            cg transfer flowcell $FC &> ${HASTA_DEMUXES_DIR}/${run}/cg.transfer.${FC}.${NOW}.log
 
             # send an email on completion
             SUBJECT=${FC}

--- a/scripts/checkfornewdemuxonhasta.bash
+++ b/scripts/checkfornewdemuxonhasta.bash
@@ -6,6 +6,7 @@
 
 HASTA_DEMUXES_DIR=${1-${PROJECT_HOME}/${ENVIRONMENT}/demultiplexed-runs/}
 ERROR_EMAIL=${2-clinical-demux@scilifelab.se}
+MAILTO=${clinical-demux@scilifelab.se}
 
 #############
 # FUNCTIONS #
@@ -56,8 +57,8 @@ for run in ${HASTA_DEMUXES_DIR}/*; do
 
             # send an email on completion
             SUBJECT=${FC}
-            log "column -t ${UNABASE}${run}/stats*.txt | mail -s 'Run ${SUBJECT} COMPLETE!' ${MAILTO}"
-            column -t ${UNABASE}${run}/stats*.txt | mail -s "Run ${SUBJECT} COMPLETE!" ${MAILTO}
+            log "column -t ${HASTA_DEMUXES_DIR}/${run}/stats*.txt | mail -s 'Run ${SUBJECT} COMPLETE!' ${MAILTO}"
+            column -t ${HASTA_DEMUXES_DIR}/${run}/stats*.txt | mail -s "Run ${SUBJECT} COMPLETE!" ${MAILTO}
         fi
     else
         log ${run} 'is not yet completely copied'

--- a/scripts/checkfornewdemuxonhasta.bash
+++ b/scripts/checkfornewdemuxonhasta.bash
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-shopt -s expand_aliases
-source ${HOME}/.bashrc
-useprod
-
 ########
 # VARS #
 ########

--- a/scripts/checkfornewdemuxonhasta.bash
+++ b/scripts/checkfornewdemuxonhasta.bash
@@ -6,7 +6,7 @@
 
 HASTA_DEMUXES_DIR=${1-${PROJECT_HOME}/${ENVIRONMENT}/demultiplexed-runs/}
 ERROR_EMAIL=${2-clinical-demux@scilifelab.se}
-MAILTO=${clinical-demux@scilifelab.se}
+MAILTO=${2-clinical-demux@scilifelab.se}
 
 #############
 # FUNCTIONS #


### PR DESCRIPTION
This PR prepares the deliver script to run bash functions instead of bash aliases.

How to test?
1. install on stage: `bash update-deliver-stage.sh checkfornewdemux-hasta`
1. install servers on stage: `bash update-servers-stage.sh`
1. `rm /home/proj/stage/demultiplexed-runs/181218_ST-E00266_0336_BHVTWHCCXY/delivery.txt`
1. run: `source /home/proj/stage/servers/resources/hasta.scilifelab.se/usestage.sh`
1. run: `bash /home/proj/stage/bin/git/deliver/scripts/checkfornewdemuxonhasta.bash`

Expected outcome:
1. exit code 0 :)
1. in ` /home/proj/stage/demultiplexed-runs/181218_ST-E00266_0336_BHVTWHCCXY` the stats-* files should be newly created and not zero sized.

Sign offs:
- [x] code review by @barrystokman 
- [x] testing done by @emiliaol 
- [x] approval for deploy by @ingkebil

This is minor version bump: we extend the functionality. We have also changed how one parameter is passed into the script as well as simplified how the activate environment was detected. Both changes would only warrant a patch change.