### PR TITLE
lint checkfornewdemuxonhasta.bash

### DIFF
--- a/scripts/checkfornewdemuxonhasta.bash
+++ b/scripts/checkfornewdemuxonhasta.bash
@@ -1,23 +1,32 @@
 #!/bin/bash
 
+shopt -s expand_aliases
+source ${HOME}/.bashrc
+if [[ ${ENVIRONMENT} == 'production' ]]; then
+    useprod
+else
+    usestage
+fi
+
 ########
 # VARS #
 ########
 
 HASTA_DEMUXES_DIR=${1-${PROJECT_HOME}/${ENVIRONMENT}/demultiplexed-runs/}
-MAILTO=${2-clinical-demux@scilifelab.se}
+MAILTO=${2-clinical-demux@scilifelab.se} # split on ',' to provide multiple
 
 #############
 # FUNCTIONS #
 #############
 
 log() {
-    local NOW=$(date +"%Y%m%d%H%M%S")
-    echo "[$NOW] $@"
+    local NOW
+    NOW=$(date +"%Y%m%d%H%M%S")
+    echo "[$NOW] $*"
 }
 
 failed() {
-    echo "Error delivering ${FC}: $(caller)" | mail -s "ERROR delivery ${FC}" ${MAILTO}
+    echo "Error delivering ${FC}: $(caller)" | mail -s "ERROR delivery ${FC}" "${MAILTO}"
 }
 trap failed ERR
 
@@ -25,41 +34,42 @@ trap failed ERR
 # MAIN #
 ########
 
-for run in ${HASTA_DEMUXES_DIR}/*; do
-    run=$(basename $run)
+for run in "${HASTA_DEMUXES_DIR}"/*; do
+    run=$(basename "$run")
     if [[ -f ${HASTA_DEMUXES_DIR}/${run}/copycomplete.txt ]]; then
         if [[ -f ${HASTA_DEMUXES_DIR}/${run}/delivery.txt ]]; then
-            log ${run} 'copy is complete and delivery has already started'
+            log "${run}" 'copy is complete and delivery has already started'
         else
-            log ${run} 'copy is complete delivery is started' > ${HASTA_DEMUXES_DIR}/${run}/delivery.txt
-            FC=$(echo ${run} | awk 'BEGIN {FS="/"} {split($(NF-1),arr,"_");print substr(arr[4],2,length(arr[4]))}')
+            log "${run}" 'copy is complete delivery is started' > "${HASTA_DEMUXES_DIR}/${run}/delivery.txt"
+            FC=${run##*_}
+            FC=${FC:1}
 
             # add an X FC to clinstatsdb - because the permanent tunnel is not active on the nodes.
             if [[ -d "${HASTA_DEMUXES_DIR}/${run}/l1t11" ]]; then
                 log "cgstats add --machine X ${HASTA_DEMUXES_DIR}/${run}"
-                cgstats add --machine X ${HASTA_DEMUXES_DIR}/${run}
+                cgstats add --machine X "${HASTA_DEMUXES_DIR}/${run}"
                 # create stats per project
-                for PROJECT in ${HASTA_DEMUXES_DIR}/${run}/Unaligned/Project*; do
-                    PROJECT=$(basename $PROJECT)
+                for PROJECT in "${HASTA_DEMUXES_DIR}/${run}"/Unaligned/Project*; do
+                    PROJECT=$(basename "$PROJECT")
                     PROJECT_NR=${PROJECT##*_}
-                    log "cgstats select --project ${PROJECT_NR} ${FC} &> ${HASTA_DEMUXES_DIR}/${run}/stats-${PROJECT_NR}-${FC}.txt"
-                    cgstats select --project ${PROJECT_NR} ${FC} &> ${HASTA_DEMUXES_DIR}/${run}/stats-${PROJECT_NR}-${FC}.txt
+                    log "cgstats select --project '${PROJECT_NR}' '${FC}' &> '${HASTA_DEMUXES_DIR}/${run}/stats-${PROJECT_NR}-${FC}.txt'"
+                         cgstats select --project "${PROJECT_NR}" "${FC}" &> "${HASTA_DEMUXES_DIR}/${run}/stats-${PROJECT_NR}-${FC}.txt"
                 done
                 # create stats per lane
-                log "cgstats lanestats ${HASTA_DEMUXES_DIR}/${run} &> ${HASTA_DEMUXES_DIR}/${run}/stats.txt"
-                cgstats lanestats ${HASTA_DEMUXES_DIR}/${run} &> ${HASTA_DEMUXES_DIR}/${run}/stats.txt
+                log "cgstats lanestats '${HASTA_DEMUXES_DIR}/${run}' &> '${HASTA_DEMUXES_DIR}/${run}/stats.txt'"
+                     cgstats lanestats "${HASTA_DEMUXES_DIR}/${run}" &> "${HASTA_DEMUXES_DIR}/${run}/stats.txt"
             fi
             # end add
   
             NOW=$(date +"%Y%m%d%H%M%S")
-            cg transfer flowcell $FC &> ${HASTA_DEMUXES_DIR}/${run}/cg.transfer.${FC}.${NOW}.log
+            cg transfer flowcell "$FC" &> "${HASTA_DEMUXES_DIR}/${run}/cg.transfer.${FC}.${NOW}.log"
 
             # send an email on completion
             SUBJECT=${FC}
             log "column -t ${HASTA_DEMUXES_DIR}/${run}/stats*.txt | mail -s 'Run ${SUBJECT} COMPLETE!' ${MAILTO}"
-            column -t ${HASTA_DEMUXES_DIR}/${run}/stats*.txt | mail -s "Run ${SUBJECT} COMPLETE!" ${MAILTO}
+            column -t "${HASTA_DEMUXES_DIR}/${run}"/stats*.txt | mail -s "Run ${SUBJECT} COMPLETE!" "${MAILTO}"
         fi
     else
-        log ${run} 'is not yet completely copied'
+        log "${run}" 'is not yet completely copied'
     fi
 done


### PR DESCRIPTION
This PR fixes the problem with no env loaded when running the script in a crontab.

How to test case 1:
0. clone locally: ~/git/deliver
1. the run is already demuxed and available here: `/home/proj/stage/demultiplexed-runs/180119_ST-E00266_0265_AHHHVTCCXY`
1. clear the stats: `us; cgstats delete -f HHHVTCCXY`
1. set your crontab:
```
SHELL=/bin/bash
CRONIC=/home/proj/production/servers/resources/cronic
MAILTO=kenny.billiau@scilifelab.se
LOG_BASE=/home/kenny.billiau/logs

* * * * * ENVIRONMENT=stage $CRONIC /home/kenny.billiau/git/deliver/scripts/checkfornewdemuxonhasta.bash >> ${LOG_BASE}/cg.store.log 2> >(tee -a ${LOG_BASE}/cg.store.log >&2)
```

Expected outcome:
stats files generated here: `/home/proj/stage/demultiplexed-runs/180119_ST-E00266_0265_AHHHVTCCXY`

Test case 2:
it looks like we also do a cg transfer! I can't think of a test case to test that one. Maybe someone has an idea? e.g. removing the fc from statusdb-stage and when this script runs, the fc will be added again?

- [x] code review by @barrystokman 
- [x] testing by @emiliaol 
- [x] deploy ok'd by @ingkebil 

This is a patch: no new functionality, only making sure it works.