### PR TITLE
Fix 'useprod' and 'usestage' not found

### DIFF
--- a/scripts/checkfornewdemuxonhasta.bash
+++ b/scripts/checkfornewdemuxonhasta.bash
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+SET_ENVIRONMENT=${ENVIRONMENT}
+
 shopt -s expand_aliases
 source ${HOME}/.bashrc
-if [[ ${ENVIRONMENT} == 'production' ]]; then
+if [[ ${SET_ENVIRONMENT} == 'production' ]]; then
     useprod
 else
     usestage


### PR DESCRIPTION
This PR fixes 'useprod: command not found'.

How to test:
1. ... this seems to be in production for 8 months already.

Expected outcome:

This is a patch version bump: bug fix.