### PR TITLE
Ci/build jobs with py 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,49 +1,53 @@
 language: python
-# 2.7 on hasta
-
+python: "3.8"   # default in jobs
 cache: pip
 
 jobs:
   include:
-    - name: "production dependencies"
-      python: 2.7
-      #if: type = pull_request
+
+    - name: "Tests on python 2.7"
+      if: type = pull_request
+      python: "2.7"   # on hasta
+      install: pip install -U -r requirements.txt -r requirements-dev.txt .
+      script: pytest
+
+    - name: "Package install"
+      if: type = pull_request
+      install: python setup.py install
+      script: true
+
+    - name: "Production dependencies on python 2.7"
+      if: type = pull_request
+      python: "2.7"   # on hasta
       install:
-        - pip install pip==19.0.1
+        - pip install pip==19.0.1  # pip version in prod170926
+        - pip install -U cython
+        - pip install -U -r requirements.txt
+      script: pip check
+
+    - name: "Development dependencies"
+      if: type = pull_request
+      install:
         - pip install cython
-        - pip install -U -r requirements.txt .
-      script:
-        - pip check
-    - name: "development dependencies"
-      python: 2.7
-      #if: type = pull_request
+        - pip install -U -r requirements.txt -r requirements-dev.txt .
+      script: pip check
+
+    - name: "Coverage"
+      if: NOT type = pull_request
       install:
-        - pip install cython
-        - pip install -U -r requirements.txt .
-        - pip install -U -r requirements-dev.txt .
-      script:
-        - pip check
-    - name: "test & coverage"
-      python: 2.7
-      #if: NOT type = pull_request
-      install:
-        - pip install -U -r requirements.txt .
-        - pip install -U -r requirements-dev.txt .
-      script:
-        - coverage run --branch --omit="*.html" --source "$(basename "$PWD")" setup.py test
-      after_success:
-        - coveralls
-    - name: "code formatting"
-      python: 3.8
-      #if: type = pull_request
+        - pip install -U cython
+        - pip install -U -r requirements.txt -r requirements-dev.txt .
+      script: coverage run --branch --omit="*.html" --source "$(basename "$PWD")" setup.py test
+      after_success: coveralls
+
+    - name: "Code formatting"
+      if: type = pull_request
       install: pip install -U black
-      script:
-        - git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" | xargs black --check
-    - name: "pylint score"
-      python: 3.8
-      #if: type = pull_request
-      install:
-        - pip install -U pylint
+      script: git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" | xargs black --check
+
+    - name: "Pylint score"
+      if: type = pull_request
+      install: pip install -U pylint
       script:
         - grep -r -E "pylint. {0,1}disable\=" .; if [ $? -eq 0 ]; then echo "Can not run pylint scoring with any pylint warnings disabled, please remove them and try again" && false; else true; fi
         - (git --no-pager diff --name-only --diff-filter=M $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/before_files.txt
@@ -52,13 +56,11 @@ jobs:
         - git checkout $TRAVIS_BRANCH
         - pylint --rcfile=.configs/pylintrc --jobs=0 --exit-zero $(< $TRAVIS_HOME/before_files.txt) > $TRAVIS_HOME/pylint_before_output.txt
         - grep -F "/10, -" $TRAVIS_HOME/pylint_before_output.txt || grep -F "/10, +0.00" $TRAVIS_HOME/pylint_before_output.txt || (echo "pylint score decreased, please try again after fixing some lint issues." && cat $TRAVIS_HOME/pylint_after_output.txt && false)
-    - name: "linting"
-      python: 3.8
-      #if: type = pull_request
-      install:
-        - pip install -U -r requirements-dev.txt
-      script:
-        - git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
+
+    - name: "Linting"
+      if: type = pull_request
+      install: pip install -U -r requirements-dev.txt
+      script: git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
 
 notifications:
   email: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       install:
         - pip install pip==19.0.1  # pip version in P_deliver
         - pip install -U cython
-        - pip install -U -r requirements.txt
+        - pip install -U -r requirements.txt .
       script: pip check
 
     - name: "Development dependencies"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
+# 3.7 for jobs on travis
 # 2.7 on hasta
 python:
+  - "3.7"
   - "2.7"
 
 # command to install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
       script: pip check
 
     - name: "Coverage"
-      if: NOT type = push
+      if: NOT type = pull_request
       python: "2.7.15"   # on P_deliver
       install:
         - pip install cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,26 +8,30 @@ jobs:
     - name: "production dependencies"
       python: 2.7
       #if: type = pull_request
+      install:
+          - pip install pip==19.0.1
+          - pip install cython
+          - pip install -U -r requirements.txt .
       script:
-        - pip install pip==19.0.1
-        - pip install cython
-        - pip install -U -r requirements.txt .
         - pip check
     - name: "development dependencies"
       python: 2.7
       #if: type = pull_request
-      script:
+      install:
         - pip install cython
         - pip install -U -r requirements.txt .
         - pip install -U -r requirements-dev.txt .
+      script:
         - pip check
     - name: "test & coverage"
       python: 2.7
       #if: NOT type = pull_request
-      script:
+      install:
         - pip install -U -r requirements.txt .
         - pip install -U -r requirements-dev.txt .
+      script:
         - coverage run --branch --omit="*.html" --source "$(basename "$PWD")" setup.py test
+      after_success:
         - coveralls
     - name: "code formatting"
       python: 3.8
@@ -38,8 +42,9 @@ jobs:
     - name: "pylint score"
       python: 3.8
       #if: type = pull_request
-      script:
+      install:
         - pip install -U pylint
+      script:
         - grep -r -E "pylint. {0,1}disable\=" .; if [ $? -eq 0 ]; then echo "Can not run pylint scoring with any pylint warnings disabled, please remove them and try again" && false; else true; fi
         - (git --no-pager diff --name-only --diff-filter=M $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/before_files.txt
         - (git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/after_files.txt
@@ -50,8 +55,9 @@ jobs:
     - name: "linting"
       python: 3.8
       #if: type = pull_request
-      script:
+      install:
         - pip install -U -r requirements-dev.txt
+      script:
         - git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
-# 3.7 for jobs on travis
+# 3.6 for jobs on travis
 # 2.7 on hasta
 python:
-  - "3.7"
+  - "3.6"
   - "2.7"
 
 # command to install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ jobs:
       python: 2.7
       #if: type = pull_request
       script:
-        - pip install pip==19.0.1
         - pip install cython
         - pip install -U -r requirements.txt .
         - pip install -U -r requirements-dev.txt .

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,10 @@ jobs:
         - pylint --rcfile=.configs/pylintrc --jobs=0 --exit-zero $(< $TRAVIS_HOME/after_files.txt) > $TRAVIS_HOME/pylint_after_output.txt
         - git checkout $TRAVIS_BRANCH
         - pylint --rcfile=.configs/pylintrc --jobs=0 --exit-zero $(< $TRAVIS_HOME/before_files.txt) > $TRAVIS_HOME/pylint_before_output.txt
-        - grep -F "/10, -" $TRAVIS_HOME/pylint_before_output.txt || grep -F "/10, +0.00" $TRAVIS_HOME/pylint_before_output.txt || (echo "pylint score decreased, please try again after fixing some lint issues." && cat $TRAVIS_HOME/pylint_after_output.txt && false)
+        - >-
+          grep -F "/10, -" $TRAVIS_HOME/pylint_before_output.txt ||
+          grep -F "/10, +0.00" $TRAVIS_HOME/pylint_before_output.txt ||
+          (echo "pylint score decreased, please try again after fixing some lint issues." && cat $TRAVIS_HOME/pylint_after_output.txt && false)
 
     - name: "Linting"
       if: type = pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,15 @@ jobs:
       python: 2.7
       #if: NOT type = pull_request
       script:
-        - pip install -U -r requirements-dev.txt
+        - pip install -U -r requirements.txt .
+        - pip install -U -r requirements-dev.txt .
         - coverage run --branch --omit="*.html" --source "$(basename "$PWD")" setup.py test
         - coveralls
     - name: "code formatting"
       python: 3.8
       #if: type = pull_request
+      install: pip install -U black
       script:
-        - pip install -U black
         - git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" | xargs black --check
     - name: "pylint score"
       python: 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ jobs:
   include:
 
     - name: "Tests on python 2.7 (Hasta)"
-      if: type = pull_request
       python: "2.7.15"   # on P_deliver
       install: pip install . -r requirements-dev.txt
       script: pytest
@@ -14,7 +13,7 @@ jobs:
       if: type = pull_request
       python: "2.7.15"   # on P_deliver
       install: python setup.py install
-      script: true
+      script: pip check
 
     - name: "Production dependencies on Hasta"
       if: type = pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ jobs:
       python: 2.7
       #if: type = pull_request
       install:
-          - pip install pip==19.0.1
-          - pip install cython
-          - pip install -U -r requirements.txt .
+        - pip install pip==19.0.1
+        - pip install cython
+        - pip install -U -r requirements.txt .
       script:
         - pip check
     - name: "development dependencies"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ cache: pip
 jobs:
   include:
 
-    - name: "Tests on python 2.7"
+    - name: "Tests on python 2.7 (Hasta)"
       if: type = pull_request
-      python: "2.7"   # on hasta
+      python: "2.7.15"   # on P_deliver
       install: pip install -U -r requirements.txt -r requirements-dev.txt .
       script: pytest
 
@@ -16,11 +16,11 @@ jobs:
       install: python setup.py install
       script: true
 
-    - name: "Production dependencies on python 2.7"
+    - name: "Production dependencies on Hasta"
       if: type = pull_request
-      python: "2.7"   # on hasta
+      python: "2.7.15"            # on P_deliver
       install:
-        # - pip install pip==19.0.1  # pip version in prod170926
+        - pip install pip==19.0.1  # pip version in P_deliver
         - pip install -U cython
         - pip install -U -r requirements.txt
       script: pip check

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - pip install -U -r requirements.txt .
 # command to run tests
 script:
-  - pytest
+#  - pytest
 
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
       if: type = pull_request
       python: "2.7"   # on hasta
       install:
-        - pip install pip==19.0.1  # pip version in prod170926
+        # - pip install pip==19.0.1  # pip version in prod170926
         - pip install -U cython
         - pip install -U -r requirements.txt
       script: pip check

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,29 +28,29 @@ cache: pip
 jobs:
   include:
     - name: "production dependencies"
-      if: type = pull_request
+      #if: type = pull_request
       script:
         - pip check
     - name: "development dependencies"
-      if: type = pull_request
+      #if: type = pull_request
       script:
         - pip install -U -r requirements-dev.txt .
         - pip check
     - name: "coverage"
-      if: NOT type = pull_request
+      #if: NOT type = pull_request
       script:
         - pip install --upgrade pip
         - pip install -U -r requirements-dev.txt
         - coverage run --branch --omit="*.html" --source "$(basename "$PWD")" setup.py test
         - coveralls
     - name: "code formatting"
-      if: type = pull_request
+      #if: type = pull_request
       script:
         - pip install --upgrade pip
         - pip install black
         - git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" | xargs black --check
     - name: "pylint score"
-      if: type = pull_request
+      #if: type = pull_request
       script:
         - pip install --upgrade pip && pip install -U -r requirements-dev.txt .
         - grep -r -E "pylint. {0,1}disable\=" .; if [ $? -eq 0 ]; then echo "Can not run pylint scoring with any pylint warnings disabled, please remove them and try again" && false; else true; fi
@@ -61,7 +61,7 @@ jobs:
         - pylint --rcfile=.configs/pylintrc --jobs=0 --exit-zero $(< $TRAVIS_HOME/before_files.txt) > $TRAVIS_HOME/pylint_before_output.txt
         - grep -F "/10, -" $TRAVIS_HOME/pylint_before_output.txt || grep -F "/10, +0.00" $TRAVIS_HOME/pylint_before_output.txt || (echo "pylint score decreased, please try again after fixing some lint issues." && cat $TRAVIS_HOME/pylint_after_output.txt && false)
     - name: "linting"
-      if: type = pull_request
+      #if: type = pull_request
       script:
         - pip install --upgrade pip
         - pip install -U -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ python:
   - "3.6"
   - "3.5"
   - "3.4"
-  - "3.3"
-  - "3.2"
-  - "3.1"
-  - "3.0"
   - "2.7"
 
 # command to install dependencies
@@ -18,7 +14,6 @@ python:
 install:
   - pip install pip==19.0.1
   - pip install cython
-  - pip install -U -r requirements.txt .
 # command to run tests
 script:
 #  - pytest
@@ -30,29 +25,31 @@ jobs:
     - name: "production dependencies"
       #if: type = pull_request
       script:
+        - pip install -U -r requirements.txt .
         - pip check
     - name: "development dependencies"
       #if: type = pull_request
       script:
+        - pip install -U -r requirements.txt .
         - pip install -U -r requirements-dev.txt .
         - pip check
     - name: "coverage"
       #if: NOT type = pull_request
       script:
         - pip install --upgrade pip
+        - pip install -U -r requirements.txt .
         - pip install -U -r requirements-dev.txt
         - coverage run --branch --omit="*.html" --source "$(basename "$PWD")" setup.py test
         - coveralls
     - name: "code formatting"
       #if: type = pull_request
       script:
-        - pip install --upgrade pip
-        - pip install black
+        - pip install --upgrade pip && pip install -U black
         - git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" | xargs black --check
     - name: "pylint score"
       #if: type = pull_request
       script:
-        - pip install --upgrade pip && pip install -U -r requirements-dev.txt .
+        - pip install --upgrade pip && pip install -U pylint
         - grep -r -E "pylint. {0,1}disable\=" .; if [ $? -eq 0 ]; then echo "Can not run pylint scoring with any pylint warnings disabled, please remove them and try again" && false; else true; fi
         - (git --no-pager diff --name-only --diff-filter=M $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/before_files.txt
         - (git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/after_files.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-
 cache: pip
 
 jobs:
@@ -13,6 +12,7 @@ jobs:
 
     - name: "Package install"
       if: type = pull_request
+      python: "2.7.15"   # on P_deliver
       install: python setup.py install
       script: true
 
@@ -27,6 +27,7 @@ jobs:
 
     - name: "Development dependencies"
       if: type = pull_request
+      python: "2.7.15"   # on P_deliver
       install:
         - pip install cython
         - pip install -U -r requirements.txt -r requirements-dev.txt .
@@ -34,6 +35,7 @@ jobs:
 
     - name: "Coverage"
       if: NOT type = pull_request
+      python: "2.7.15"   # on P_deliver
       install:
         - pip install -U cython
         - pip install -U -r requirements.txt -r requirements-dev.txt .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,55 +1,45 @@
 language: python
-# 3.6 for jobs on travis
 # 2.7 on hasta
-python:
-  - "3.8"
-  - "3.7"
-  - "3.6"
-  - "3.5"
-  - "3.4"
-  - "2.7"
-
-# command to install dependencies
-# pip locked to version in P_deliver
-install:
-  - pip install pip==19.0.1
-  - pip install cython
-# command to run tests
-script:
-#  - pytest
 
 cache: pip
 
 jobs:
   include:
     - name: "production dependencies"
+      python: 2.7
       #if: type = pull_request
       script:
+        - pip install pip==19.0.1
+        - pip install cython
         - pip install -U -r requirements.txt .
         - pip check
     - name: "development dependencies"
+      python: 2.7
       #if: type = pull_request
       script:
+        - pip install pip==19.0.1
+        - pip install cython
         - pip install -U -r requirements.txt .
         - pip install -U -r requirements-dev.txt .
         - pip check
-    - name: "coverage"
+    - name: "test & coverage"
+      python: 2.7
       #if: NOT type = pull_request
       script:
-        - pip install --upgrade pip
-        - pip install -U -r requirements.txt .
         - pip install -U -r requirements-dev.txt
         - coverage run --branch --omit="*.html" --source "$(basename "$PWD")" setup.py test
         - coveralls
     - name: "code formatting"
+      python: 3.8
       #if: type = pull_request
       script:
-        - pip install --upgrade pip && pip install -U black
+        - pip install -U black
         - git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" | xargs black --check
     - name: "pylint score"
+      python: 3.8
       #if: type = pull_request
       script:
-        - pip install --upgrade pip && pip install -U pylint
+        - pip install -U pylint
         - grep -r -E "pylint. {0,1}disable\=" .; if [ $? -eq 0 ]; then echo "Can not run pylint scoring with any pylint warnings disabled, please remove them and try again" && false; else true; fi
         - (git --no-pager diff --name-only --diff-filter=M $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/before_files.txt
         - (git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/after_files.txt
@@ -58,9 +48,9 @@ jobs:
         - pylint --rcfile=.configs/pylintrc --jobs=0 --exit-zero $(< $TRAVIS_HOME/before_files.txt) > $TRAVIS_HOME/pylint_before_output.txt
         - grep -F "/10, -" $TRAVIS_HOME/pylint_before_output.txt || grep -F "/10, +0.00" $TRAVIS_HOME/pylint_before_output.txt || (echo "pylint score decreased, please try again after fixing some lint issues." && cat $TRAVIS_HOME/pylint_after_output.txt && false)
     - name: "linting"
+      python: 3.8
       #if: type = pull_request
       script:
-        - pip install --upgrade pip
         - pip install -U -r requirements-dev.txt
         - git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
       script: pip check
 
     - name: "Coverage"
-      if: NOT type = pull_request
+      if: NOT type = push
       python: "2.7.15"   # on P_deliver
       install:
         - pip install cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,15 @@ language: python
 # 3.6 for jobs on travis
 # 2.7 on hasta
 python:
+  - "3.8"
+  - "3.7"
   - "3.6"
+  - "3.5"
+  - "3.4"
+  - "3.3"
+  - "3.2"
+  - "3.1"
+  - "3.0"
   - "2.7"
 
 # command to install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: "3.8"   # default in jobs
+
 cache: pip
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
     - name: "Tests on python 2.7 (Hasta)"
       if: type = pull_request
       python: "2.7.15"   # on P_deliver
-      install: pip install -U -r requirements.txt -r requirements-dev.txt .
+      install: pip install . -r requirements-dev.txt
       script: pytest
 
     - name: "Package install"
@@ -21,8 +21,8 @@ jobs:
       python: "2.7.15"            # on P_deliver
       install:
         - pip install pip==19.0.1  # pip version in P_deliver
-        - pip install -U cython
-        - pip install -U -r requirements.txt .
+        - pip install cython
+        - pip install .
       script: pip check
 
     - name: "Development dependencies"
@@ -30,26 +30,26 @@ jobs:
       python: "2.7.15"   # on P_deliver
       install:
         - pip install cython
-        - pip install -U -r requirements.txt -r requirements-dev.txt .
+        - pip install . -r requirements-dev.txt
       script: pip check
 
     - name: "Coverage"
       if: NOT type = pull_request
       python: "2.7.15"   # on P_deliver
       install:
-        - pip install -U cython
-        - pip install -U -r requirements.txt -r requirements-dev.txt .
+        - pip install cython
+        - pip install . -r requirements-dev.txt
       script: coverage run --branch --omit="*.html" --source "$(basename "$PWD")" setup.py test
       after_success: coveralls
 
     - name: "Code formatting"
       if: type = pull_request
-      install: pip install -U black
+      install: pip install black
       script: git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" | xargs black --check
 
     - name: "Pylint score"
       if: type = pull_request
-      install: pip install -U pylint
+      install: pip install pylint
       script:
         - grep -r -E "pylint. {0,1}disable\=" .; if [ $? -eq 0 ]; then echo "Can not run pylint scoring with any pylint warnings disabled, please remove them and try again" && false; else true; fi
         - (git --no-pager diff --name-only --diff-filter=M $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/before_files.txt
@@ -64,7 +64,7 @@ jobs:
 
     - name: "Linting"
       if: type = pull_request
-      install: pip install -U -r requirements-dev.txt
+      install: pip install -r requirements-dev.txt
       script: git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
 
 notifications:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,5 +12,4 @@ html-linter
 tidy
 six>=1.12                   # due to astroid 2.3.3
 python-coveralls
-black
 pre-commit


### PR DESCRIPTION
PR changes to py 2.7.15 for CI-builds in the delivery repo

**How to test: **
- [x] open travis checks

**Expected outcome: **
- [x] all package installs should be with python 2.7.15 
- [x] Screenshot

- [x] Reviewed by @adrosenbaum 
- [x] Tested @patrikgrenfeldt 
- [x] merge & deploy OK 

This is a patch bump since we fix issues on the CI